### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -51,6 +54,8 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/khive-ai/lionagi/security/code-scanning/3](https://github.com/khive-ai/lionagi/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, as the workflow primarily involves testing and building code. For the `publish` job, additional permissions may be required if it interacts with GitHub Packages or other resources, but this is not evident from the provided snippet. We will start with `contents: read` for both jobs and adjust if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
