### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: write
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/khive-ai/lionagi/security/code-scanning/1](https://github.com/khive-ai/lionagi/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps:
1. The `actions/checkout@v4` action requires `contents: read` to check out the repository.
2. The `peaceiris/actions-gh-pages@v4` action requires `contents: write` to deploy the built documentation to GitHub Pages.

We will set `contents: write` as the minimal required permission for the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
