### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -52,6 +55,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/khive-ai/lionagi/security/code-scanning/6](https://github.com/khive-ai/lionagi/security/code-scanning/6)

To fix the issue:
1. Add a `permissions` block at the root level of the workflow to apply minimal privileges globally to all jobs, unless overridden at the job level.
2. Use the principle of least privilege by setting `contents: read`, allowing the workflow to read repository contents while preventing unnecessary write access.
3. If specific jobs require additional permissions (e.g., `publish`), define a more permissive `permissions` block within those jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
