### PR TITLE
fix(ci): update baseline refresh workflow for branch protection compliance

### DIFF
--- a/.github/workflows/refresh-bench-baselines.yml
+++ b/.github/workflows/refresh-bench-baselines.yml
@@ -64,13 +64,29 @@ jobs:
           cp benchmarks/_ci_out/ln-trio.json benchmarks/baselines/ln-trio.json
           cp benchmarks/_ci_out/fuzzy.json benchmarks/baselines/fuzzy.json
 
-      - name: Commit and push updated baselines
+      - name: Commit and create PR for updated baselines
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          
+          # Create a unique branch name with timestamp
+          BRANCH_NAME="chore/refresh-baselines-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          
+          # Add and commit changes
           git add benchmarks/baselines/*.json
           git commit -m "chore(benchmarks): refresh CI-native baselines [skip ci]"
-          git push origin main
+          
+          # Push the branch
+          git push origin "$BRANCH_NAME"
+          
+          # Create pull request using GitHub CLI
+          gh pr create \
+            --title "chore(benchmarks): refresh CI-native baselines" \
+            --body "Automated refresh of benchmark baselines from GitHub Actions workflow." \
+            --label "chore" \
+            --head "$BRANCH_NAME" \
+            --base main
 
       - name: Upload baselines artifact (fallback)
         if: ${{ failure() }}


### PR DESCRIPTION
## Summary

Fixes the baseline refresh GitHub Actions workflow to comply with repository branch protection rules.

## Problem
The current workflow tries to push directly to main branch, which violates repository rules requiring changes to go through pull requests.

## Solution
- Modified refresh-bench-baselines.yml to create a timestamped branch instead of pushing to main
- Uses GitHub CLI to automatically create a pull request for baseline updates
- Maintains the same baseline refresh functionality while respecting branch protection

## Changes
- Updated workflow to create branch with timestamp
- Replaced direct push with gh pr create command
- Added descriptive PR title and labels for automated baseline updates

## Testing
- Workflow syntax validated
- Will test via workflow dispatch after merge

Fixes baseline refresh failures caused by repository rule violations.