### PR TITLE
fix(ci): add GH_TOKEN environment variable for GitHub CLI authentication

### DIFF
--- a/.github/workflows/refresh-bench-baselines.yml
+++ b/.github/workflows/refresh-bench-baselines.yml
@@ -65,6 +65,8 @@ jobs:
           cp benchmarks/_ci_out/fuzzy.json benchmarks/baselines/fuzzy.json
 
       - name: Commit and create PR for updated baselines
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -84,7 +86,7 @@ jobs:
           gh pr create \
             --title "chore(benchmarks): refresh CI-native baselines" \
             --body "Automated refresh of benchmark baselines from GitHub Actions workflow." \
-            --label "chore" \
+            --label "enhancement" \
             --head "$BRANCH_NAME" \
             --base main
 


### PR DESCRIPTION
- Added missing GH_TOKEN env var to allow gh pr create to work in Actions
- Changed label from 'chore' to 'enhancement' (chore label doesn't exist)
- Fixes authentication error: 'set the GH_TOKEN environment variable'