### PR TITLE
refactor: coerce single FieldModel instance to list in ModelParams

### DIFF
--- a/lionagi/models/model_params.py
+++ b/lionagi/models/model_params.py
@@ -172,14 +172,21 @@ class ModelParams(Params):
 
         # Process field_models
         if not self._is_sentinel(self.field_models):
-            for fm in self.field_models:
+            # Coerce to list if single FieldModel instance
+            field_models_list = (
+                [self.field_models]
+                if isinstance(self.field_models, FieldModel)
+                else self.field_models
+            )
+
+            for fm in field_models_list:
                 if not isinstance(fm, FieldModel):
                     raise ValueError(
                         f"field_models must contain FieldModel instances, got {type(fm)}"
                     )
 
             # Apply descriptions first
-            field_models = self.field_models
+            field_models = field_models_list
             if not self._is_sentinel(self.field_descriptions):
                 field_models = [
                     (

--- a/lionagi/protocols/operatives/operative.py
+++ b/lionagi/protocols/operatives/operative.py
@@ -79,7 +79,13 @@ class Operative:
         """Initialize from ModelParams for backward compatibility."""
         # Add field models to the request operable
         if params.field_models:
-            for field_model in params.field_models:
+            # Coerce to list if single FieldModel instance
+            field_models_list = (
+                [params.field_models]
+                if isinstance(params.field_models, FieldModel)
+                else params.field_models
+            )
+            for field_model in field_models_list:
                 self._request_operable.add_field(
                     field_model.name,
                     field_model=field_model,
@@ -296,7 +302,13 @@ class Operative:
 
         # Add field models (skip if already exists from inheritance)
         if field_models:
-            for field_model in field_models:
+            # Coerce to list if single FieldModel instance
+            field_models_list = (
+                [field_models]
+                if isinstance(field_models, FieldModel)
+                else field_models
+            )
+            for field_model in field_models_list:
                 if field_model.name not in self._response_operable.all_fields:
                     self._response_operable.add_field(
                         field_model.name,


### PR DESCRIPTION
This pull request improves the robustness and consistency of handling the `field_models` parameter throughout the codebase. The main change ensures that whether a single `FieldModel` instance or a list of them is provided, the code will always process them as a list, preventing errors and simplifying downstream logic.

**Consistent handling of `field_models` parameter:**

* Updated `_process_fields` in `model_params.py` to coerce a single `FieldModel` instance into a list, ensuring uniform processing of field models.
* Modified `_init_from_model_params` and `create_response_type` in `operative.py` to similarly coerce single `FieldModel` instances into a list, standardizing how field models are iterated and added. [[1]](diffhunk://#diff-e2e9413950b0a3cf93cb74f1374abe897439340597ea2b24aff84e8544546edbL82-R88) [[2]](diffhunk://#diff-e2e9413950b0a3cf93cb74f1374abe897439340597ea2b24aff84e8544546edbL299-R311)