### PR TITLE
feat: Security hardening, utils improvements, msgspec to orjson, optional rapidfuzz

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: check-yaml
+        args: [--unsafe]
       - id: debug-statements
       - id: check-added-large-files
       - id: check-ast

--- a/lionagi/ln/__init__.py
+++ b/lionagi/ln/__init__.py
@@ -1,5 +1,13 @@
 from ._async_call import AlcallParams, BcallParams, alcall, bcall
-from ._hash import hash_dict
+from ._hash import (
+    GENESIS_HASH,
+    MAX_HASH_INPUT_BYTES,
+    HashAlgorithm,
+    compute_chain_hash,
+    compute_hash,
+    hash_dict,
+    hash_obj,
+)
 from ._json_dump import (
     get_orjson_default,
     json_dumpb,
@@ -8,13 +16,20 @@ from ._json_dump import (
     make_options,
 )
 from ._list_call import lcall
-from ._to_list import to_list
+from ._to_list import ToListParams, to_list
 from ._utils import (
     acreate_path,
+    async_synchronized,
+    coerce_created_at,
+    extract_types,
     get_bins,
     import_module,
     is_import_installed,
+    load_type_from_string,
     now_utc,
+    register_type_prefix,
+    synchronized,
+    to_uuid,
 )
 from .concurrency import (
     bounded_map,
@@ -31,6 +46,7 @@ from .concurrency import (
     retry,
 )
 from .fuzzy import (
+    MAX_JSON_INPUT_SIZE,
     SIMILARITY_TYPE,
     extract_json,
     fuzzy_json,
@@ -45,7 +61,13 @@ from .types import is_sentinel, not_sentinel
 __all__ = (
     "alcall",
     "bcall",
+    "GENESIS_HASH",
+    "HashAlgorithm",
+    "MAX_HASH_INPUT_BYTES",
+    "compute_chain_hash",
+    "compute_hash",
     "hash_dict",
+    "hash_obj",
     "get_orjson_default",
     "json_dumps",
     "make_options",
@@ -54,10 +76,17 @@ __all__ = (
     "lcall",
     "to_list",
     "acreate_path",
+    "async_synchronized",
+    "coerce_created_at",
+    "extract_types",
     "get_bins",
     "import_module",
     "is_import_installed",
+    "load_type_from_string",
     "now_utc",
+    "register_type_prefix",
+    "synchronized",
+    "to_uuid",
     "bounded_map",
     "create_task_group",
     "fail_after",
@@ -82,4 +111,6 @@ __all__ = (
     "fuzzy_validate_mapping",
     "AlcallParams",
     "BcallParams",
+    "ToListParams",
+    "MAX_JSON_INPUT_SIZE",
 )

--- a/lionagi/ln/_lazy_init.py
+++ b/lionagi/ln/_lazy_init.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Thread-safe lazy initialization utility."""
+
+import threading
+from collections.abc import Callable
+
+__all__ = ("LazyInit",)
+
+
+class LazyInit:
+    """Thread-safe lazy initialization helper using double-checked locking.
+
+    Defers expensive imports/setup until first use. Guarantees init_func
+    runs exactly once even under concurrent access.
+
+    Example:
+        _lazy = LazyInit()
+        _MODEL_LIKE = None
+
+        def _do_init():
+            global _MODEL_LIKE
+            from pydantic import BaseModel
+            _MODEL_LIKE = (BaseModel,)
+
+        def my_function(x):
+            _lazy.ensure(_do_init)
+            # _MODEL_LIKE is now initialized
+
+    Attributes:
+        initialized: True after ensure() has completed successfully.
+    """
+
+    __slots__ = ("_initialized", "_lock")
+
+    def __init__(self) -> None:
+        """Create uninitialized LazyInit instance."""
+        self._initialized = False
+        self._lock = threading.RLock()
+
+    @property
+    def initialized(self) -> bool:
+        """Check if initialization has completed."""
+        return self._initialized
+
+    def ensure(self, init_func: Callable[[], None]) -> None:
+        """Execute init_func exactly once, thread-safely.
+
+        Uses double-checked locking: fast path (no lock) when already
+        initialized, lock acquisition only on first call.
+
+        Args:
+            init_func: Initialization function. Should be idempotent
+                as a safety measure (though only called once).
+        """
+        if self._initialized:
+            return
+        with self._lock:
+            if self._initialized:
+                return
+            init_func()
+            self._initialized = True

--- a/lionagi/ln/_to_list.py
+++ b/lionagi/ln/_to_list.py
@@ -1,15 +1,22 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""List conversion utilities with flattening, deduplication, and NA handling."""
+
+from __future__ import annotations
+
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum as _Enum
 from typing import Any, ClassVar
 
 from ._hash import hash_dict
+from ._lazy_init import LazyInit
 from .types import Params
 
 __all__ = ("to_list", "ToListParams")
 
-
-_INITIALIZED = False
+_lazy = LazyInit()
 _MODEL_LIKE = None
 _MAP_LIKE = None
 _SINGLETONE_TYPES = None
@@ -17,6 +24,28 @@ _SKIP_TYPE = None
 _SKIP_TUPLE_SET = None
 _BYTE_LIKE = (str, bytes, bytearray)
 _TUPLE_SET = (tuple, set, frozenset)
+
+
+def _do_init() -> None:
+    """Initialize lazy type constants (Pydantic, sentinel types)."""
+    from pydantic import BaseModel
+    from pydantic_core import PydanticUndefinedType
+
+    from .types import UndefinedType, UnsetType
+
+    try:
+        from msgspec import Struct
+
+        _model_like = (BaseModel, Struct)
+    except ImportError:
+        _model_like = (BaseModel,)
+
+    global _MODEL_LIKE, _MAP_LIKE, _SINGLETONE_TYPES, _SKIP_TYPE, _SKIP_TUPLE_SET
+    _MODEL_LIKE = _model_like
+    _MAP_LIKE = (Mapping, *_MODEL_LIKE)
+    _SINGLETONE_TYPES = (UndefinedType, UnsetType, PydanticUndefinedType)
+    _SKIP_TYPE = (*_BYTE_LIKE, *_MAP_LIKE, _Enum)
+    _SKIP_TUPLE_SET = (*_SKIP_TYPE, *_TUPLE_SET)
 
 
 def to_list(
@@ -29,54 +58,47 @@ def to_list(
     use_values: bool = False,
     flatten_tuple_set: bool = False,
 ) -> list:
-    """Convert input to a list with optional transformations.
+    """Convert input to list with optional transformations.
 
-    Transforms various input types into a list with configurable processing
-    options for flattening, filtering, and value extraction.
+    Type handling:
+        - None/Undefined/Unset: returns []
+        - list: returned as-is (not copied)
+        - Enum class: list of members (or values if use_values=True)
+        - str/bytes/bytearray: wrapped as [input_] unless use_values=True
+        - Mapping: wrapped as [input_] unless use_values=True (extracts values)
+        - BaseModel/Struct: wrapped as [input_]
+        - Other iterables: converted via list()
+        - Non-iterables: wrapped as [input_]
 
     Args:
-        input_: Value to convert to list.
-        flatten: If True, recursively flatten nested iterables.
-        dropna: If True, remove None and undefined values.
-        unique: If True, remove duplicates (requires flatten=True).
-        use_values: If True, extract values from enums/mappings.
-        flatten_tuple_items: If True, include tuples in flattening.
-        flatten_set_items: If True, include sets in flattening.
+        input_: Value to convert.
+        flatten: Recursively flatten nested iterables.
+        dropna: Remove None and sentinel values (Undefined, Unset).
+        unique: Remove duplicates. Requires flatten=True.
+        use_values: Extract values from Enum classes and Mappings.
+        flatten_tuple_set: When flatten=True, also flatten tuples/sets/frozensets.
+
+    Returns:
+        Processed list.
 
     Raises:
-        ValueError: If unique=True is used without flatten=True.
+        ValueError: unique=True without flatten=True, or unhashable non-mapping item.
+
+    Edge Cases:
+        - Nested lists: preserved unless flatten=True
+        - Unhashable items with unique=True: falls back to hash_dict for mappings
+        - Empty input: returns []
     """
-    global _INITIALIZED
-    if _INITIALIZED is False:
-        from msgspec import Struct
-        from pydantic import BaseModel
-        from pydantic_core import PydanticUndefinedType
-
-        from .types import UndefinedType, UnsetType
-
-        global _MODEL_LIKE, _MAP_LIKE, _SINGLETONE_TYPES, _SKIP_TYPE, _SKIP_TUPLE_SET
-        _MODEL_LIKE = (BaseModel, Struct)
-        _MAP_LIKE = (Mapping, *_MODEL_LIKE)
-        _SINGLETONE_TYPES = (UndefinedType, UnsetType, PydanticUndefinedType)
-        _SKIP_TYPE = (*_BYTE_LIKE, *_MAP_LIKE, _Enum)
-        _SKIP_TUPLE_SET = (*_SKIP_TYPE, *_TUPLE_SET)
-        _INITIALIZED = True
+    _lazy.ensure(_do_init)
 
     def _process_list(
         lst: list[Any],
         flatten: bool,
         dropna: bool,
+        skip_types: tuple[type, ...],
     ) -> list[Any]:
-        """Process list according to flatten and dropna options.
-
-        Args:
-            lst: Input list to process.
-            flatten: Whether to flatten nested iterables.
-            dropna: Whether to remove None/undefined values.
-        """
-        result = []
-        skip_types = _SKIP_TYPE if flatten_tuple_set else _SKIP_TUPLE_SET
-
+        """Recursively process list with flatten/dropna logic."""
+        result: list[Any] = []
         for item in lst:
             if dropna and (
                 item is None or isinstance(item, _SINGLETONE_TYPES)
@@ -89,21 +111,20 @@ def to_list(
             if is_iterable and not should_skip:
                 item_list = list(item)
                 if flatten:
-                    result.extend(_process_list(item_list, flatten, dropna))
+                    result.extend(
+                        _process_list(item_list, flatten, dropna, skip_types)
+                    )
                 else:
-                    result.append(_process_list(item_list, flatten, dropna))
+                    result.append(
+                        _process_list(item_list, flatten, dropna, skip_types)
+                    )
             else:
                 result.append(item)
 
         return result
 
     def _to_list_type(input_: Any, use_values: bool) -> list[Any]:
-        """Convert input to initial list based on type.
-
-        Args:
-            input_: Value to convert to list.
-            use_values: Whether to extract values from containers.
-        """
+        """Convert input to initial list based on type."""
         if input_ is None or isinstance(input_, _SINGLETONE_TYPES):
             return []
 
@@ -140,7 +161,12 @@ def to_list(
         raise ValueError("unique=True requires flatten=True")
 
     initial_list = _to_list_type(input_, use_values=use_values)
-    processed = _process_list(initial_list, flatten=flatten, dropna=dropna)
+    skip_types: tuple[type, ...] = (
+        _SKIP_TYPE if flatten_tuple_set else _SKIP_TUPLE_SET
+    )
+    processed = _process_list(
+        initial_list, flatten=flatten, dropna=dropna, skip_types=skip_types
+    )
 
     if unique:
         seen = set()
@@ -148,28 +174,15 @@ def to_list(
         use_hash_fallback = False
         for i in processed:
             try:
-                if not use_hash_fallback:
-                    # Direct approach - try to use the item as hash key
-                    if i not in seen:
-                        seen.add(i)
-                        out.append(i)
-                else:
-                    # Hash-based approach for unhashable items
-                    hash_value = (
-                        hash(i)
-                        if hasattr(i, "__hash__") and i.__hash__ is not None
-                        else hash_dict(i)
-                    )
-                    if hash_value not in seen:
-                        seen.add(hash_value)
-                        out.append(i)
+                if not use_hash_fallback and i not in seen:
+                    seen.add(i)
+                    out.append(i)
             except TypeError:
-                # Switch to hash-based approach and restart
                 if not use_hash_fallback:
+                    # Restart with hash-based deduplication
                     use_hash_fallback = True
                     seen = set()
                     out = []
-                    # Restart from beginning with hash-based approach
                     for j in processed:
                         try:
                             hash_value = hash(j)
@@ -179,7 +192,7 @@ def to_list(
                             else:
                                 raise ValueError(
                                     "Unhashable type encountered in list unique value processing."
-                                )
+                                ) from None
                         if hash_value not in seen:
                             seen.add(hash_value)
                             out.append(j)

--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -1,17 +1,33 @@
+import contextlib
+import importlib
 import importlib.util
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
+from functools import wraps
 from pathlib import Path as StdPath
-from typing import Any
+from types import UnionType
+from typing import Any, ParamSpec, TypeVar, Union, get_args, get_origin
+from uuid import UUID
 
 from anyio import Path as AsyncPath
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 __all__ = (
-    "now_utc",
     "acreate_path",
+    "async_synchronized",
+    "coerce_created_at",
+    "extract_types",
     "get_bins",
     "import_module",
     "is_import_installed",
+    "load_type_from_string",
+    "now_utc",
+    "register_type_prefix",
+    "synchronized",
+    "to_uuid",
 )
 
 
@@ -22,55 +38,90 @@ def now_utc() -> datetime:
 async def acreate_path(
     directory: StdPath | AsyncPath | str,
     filename: str,
-    extension: str = None,
+    extension: str | None = None,
     timestamp: bool = False,
     dir_exist_ok: bool = True,
     file_exist_ok: bool = False,
     time_prefix: bool = False,
     timestamp_format: str | None = None,
     random_hash_digits: int = 0,
+    timeout: float | None = None,
 ) -> AsyncPath:
+    """Generate file path asynchronously with optional timeout.
+
+    Args:
+        directory: Base directory path.
+        filename: Target filename (may contain subdirectory with /).
+        extension: File extension (if filename doesn't have one).
+        timestamp: Add timestamp to filename.
+        dir_exist_ok: Allow existing directories.
+        file_exist_ok: Allow existing files.
+        time_prefix: Put timestamp before filename instead of after.
+        timestamp_format: Custom strftime format for timestamp.
+        random_hash_digits: Add random hash suffix (0 = disabled).
+        timeout: Maximum time in seconds for async I/O operations
+            (None = no timeout).
+
+    Returns:
+        AsyncPath to the created/validated file path.
+
+    Raises:
+        ValueError: If filename contains backslash.
+        FileExistsError: If file exists and file_exist_ok is False.
+        TimeoutError: If timeout is exceeded.
     """
-    Generate a new file path asynchronously with optional timestamp and a random suffix.
-    Uses non-blocking I/O (AnyIO).
-    """
+    from .concurrency import move_on_after
 
-    # Use AsyncPath for construction and execution
-    if "/" in filename:
-        sub_dir, filename = filename.split("/")[:-1], filename.split("/")[-1]
-        directory = AsyncPath(directory) / "/".join(sub_dir)
+    async def _impl() -> AsyncPath:
+        nonlocal directory, filename
 
-    if "\\" in filename:
-        raise ValueError("Filename cannot contain directory separators.")
+        if "/" in filename:
+            sub_dir, filename = (
+                filename.split("/")[:-1],
+                filename.split("/")[-1],
+            )
+            directory = AsyncPath(directory) / "/".join(sub_dir)
 
-    # Ensure directory is an AsyncPath
-    directory = AsyncPath(directory)
-    if "." in filename:
-        name, ext = filename.rsplit(".", 1)
-    else:
-        name, ext = filename, extension
-    ext = f".{ext.lstrip('.')}" if ext else ""
+        if "\\" in filename:
+            raise ValueError("Filename cannot contain directory separators.")
 
-    if timestamp:
-        # datetime.now() is generally non-blocking
-        ts_str = datetime.now().strftime(timestamp_format or "%Y%m%d%H%M%S")
-        name = f"{ts_str}_{name}" if time_prefix else f"{name}_{ts_str}"
+        directory = AsyncPath(directory)
+        if "." in filename:
+            name, ext = filename.rsplit(".", 1)
+        else:
+            name = filename
+            ext = extension or ""
+        ext = f".{ext.lstrip('.')}" if ext else ""
 
-    if random_hash_digits > 0:
-        random_suffix = uuid.uuid4().hex[:random_hash_digits]
-        name = f"{name}-{random_suffix}"
+        if timestamp:
+            ts_str = datetime.now().strftime(
+                timestamp_format or "%Y%m%d%H%M%S"
+            )
+            name = f"{ts_str}_{name}" if time_prefix else f"{name}_{ts_str}"
 
-    full_path = directory / f"{name}{ext}"
+        if random_hash_digits > 0:
+            random_suffix = uuid.uuid4().hex[:random_hash_digits]
+            name = f"{name}-{random_suffix}"
 
-    # --- CRITICAL: ASYNC I/O Operations ---
-    await full_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
+        full_path = directory / f"{name}{ext}"
 
-    if await full_path.exists() and not file_exist_ok:
-        raise FileExistsError(
-            f"File {full_path} already exists and file_exist_ok is False."
-        )
+        await full_path.parent.mkdir(parents=True, exist_ok=dir_exist_ok)
 
-    return full_path
+        if await full_path.exists() and not file_exist_ok:
+            raise FileExistsError(
+                f"File {full_path} already exists and file_exist_ok is False."
+            )
+
+        return full_path
+
+    if timeout is None:
+        return await _impl()
+
+    with move_on_after(timeout) as cancel_scope:
+        result = await _impl()
+    if cancel_scope.cancelled_caught:
+        raise TimeoutError(f"acreate_path timed out after {timeout}s")
+    return result
 
 
 def get_bins(input_: list[str], upper: int) -> list[list[int]]:
@@ -154,3 +205,225 @@ def is_import_installed(package_name: str) -> bool:
         bool: True if the package is installed, False otherwise.
     """
     return importlib.util.find_spec(package_name) is not None
+
+
+# ---------------------------------------------------------------------------
+# Dynamic type loading
+# ---------------------------------------------------------------------------
+
+_TYPE_CACHE: dict[str, type] = {}
+
+_DEFAULT_ALLOWED_PREFIXES: frozenset[str] = frozenset({"lionagi."})
+_ALLOWED_MODULE_PREFIXES: set[str] = set(_DEFAULT_ALLOWED_PREFIXES)
+
+
+def register_type_prefix(prefix: str) -> None:
+    """Register module prefix for dynamic type loading allowlist.
+
+    Security: Only register prefixes for modules you control.
+
+    Args:
+        prefix: Module prefix to allow (e.g., "myapp.models.").
+            Must end with "." to prevent prefix attacks.
+
+    Raises:
+        ValueError: If prefix doesn't end with ".".
+    """
+    if not prefix.endswith("."):
+        raise ValueError(f"Prefix must end with '.': {prefix}")
+    _ALLOWED_MODULE_PREFIXES.add(prefix)
+
+
+def load_type_from_string(type_str: str) -> type:
+    """Load type from fully qualified path (e.g., 'lionagi.core.Node').
+
+    Security: Only allowlisted module prefixes can be loaded.
+
+    Args:
+        type_str: Fully qualified type path.
+
+    Returns:
+        The loaded type class.
+
+    Raises:
+        ValueError: If path invalid, not allowlisted, or type not found.
+    """
+    if type_str in _TYPE_CACHE:
+        return _TYPE_CACHE[type_str]
+
+    if not isinstance(type_str, str):
+        raise ValueError(f"Expected string, got {type(type_str)}")
+
+    if "." not in type_str:
+        raise ValueError(f"Invalid type path (no module): {type_str}")
+
+    if not any(
+        type_str.startswith(prefix) for prefix in _ALLOWED_MODULE_PREFIXES
+    ):
+        raise ValueError(
+            f"Module '{type_str}' not in allowed prefixes: "
+            f"{sorted(_ALLOWED_MODULE_PREFIXES)}"
+        )
+
+    try:
+        module_path, class_name = type_str.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        if module is None:
+            raise ImportError(f"Module '{module_path}' not found")
+
+        type_class = getattr(module, class_name)
+        if not isinstance(type_class, type):
+            raise ValueError(f"'{type_str}' is not a type")
+
+        _TYPE_CACHE[type_str] = type_class
+        return type_class
+
+    except (ValueError, ImportError, AttributeError) as e:
+        raise ValueError(f"Failed to load type '{type_str}': {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Type extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_types(item_type: Any) -> set[type]:
+    """Extract concrete types from type annotations.
+
+    Handles Union, list, set, and single types recursively.
+
+    Args:
+        item_type: Type annotation (Union[X, Y], list[type],
+            set[type], or type).
+
+    Returns:
+        Set of concrete types extracted from the annotation.
+    """
+
+    def is_union(t: Any) -> bool:
+        origin = get_origin(t)
+        return origin is Union or isinstance(t, UnionType)
+
+    extracted: set[type] = set()
+
+    if isinstance(item_type, set):
+        for t in item_type:
+            if is_union(t):
+                extracted.update(get_args(t))
+            else:
+                extracted.add(t)
+        return extracted
+
+    if isinstance(item_type, list):
+        for t in item_type:
+            if is_union(t):
+                extracted.update(get_args(t))
+            else:
+                extracted.add(t)
+        return extracted
+
+    if is_union(item_type):
+        return set(get_args(item_type))
+
+    return {item_type}
+
+
+# ---------------------------------------------------------------------------
+# UUID / datetime coercion
+# ---------------------------------------------------------------------------
+
+
+def to_uuid(value: Any) -> UUID:
+    """Convert value to UUID instance.
+
+    Args:
+        value: UUID, UUID string, or object with ``.id`` attribute.
+
+    Returns:
+        UUID instance.
+
+    Raises:
+        ValueError: If value cannot be converted to UUID.
+    """
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str):
+        return UUID(value)
+    if hasattr(value, "id"):
+        v = value.id
+        if isinstance(v, UUID):
+            return v
+        if isinstance(v, str):
+            return UUID(v)
+    raise ValueError("Cannot get ID from item.")
+
+
+def coerce_created_at(v: Any) -> datetime:
+    """Coerce value to UTC-aware datetime.
+
+    Supports datetime, Unix timestamp (int/float), or ISO string.
+
+    Args:
+        v: datetime, Unix timestamp (int/float), or ISO string.
+
+    Returns:
+        UTC-aware datetime instance.
+
+    Raises:
+        ValueError: If value cannot be parsed as datetime.
+    """
+    if isinstance(v, datetime):
+        return v.replace(tzinfo=timezone.utc) if v.tzinfo is None else v
+
+    if isinstance(v, (int, float)):
+        return datetime.fromtimestamp(v, tz=timezone.utc)
+
+    if isinstance(v, str):
+        with contextlib.suppress(ValueError):
+            return datetime.fromtimestamp(float(v), tz=timezone.utc)
+        with contextlib.suppress(ValueError):
+            return datetime.fromisoformat(v)
+        raise ValueError(f"String '{v}' is neither timestamp nor ISO format")
+
+    raise ValueError(
+        f"Expected datetime/timestamp/string, got {type(v).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synchronization decorators
+# ---------------------------------------------------------------------------
+
+
+def synchronized(func: Callable[P, R]) -> Callable[P, R]:
+    """Decorator for thread-safe method execution.
+
+    Requires decorated method's instance to have ``self._lock``
+    (``threading.Lock``).
+    """
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        self = args[0]
+        with self._lock:
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def async_synchronized(
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    """Decorator for async-safe method execution.
+
+    Requires decorated method's instance to have ``self._async_lock``
+    (``anyio.Lock``).
+    """
+
+    @wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        self = args[0]
+        async with self._async_lock:  # type: ignore[attr-defined]
+            return await func(*args, **kwargs)
+
+    return wrapper

--- a/lionagi/ln/fuzzy/__init__.py
+++ b/lionagi/ln/fuzzy/__init__.py
@@ -1,11 +1,12 @@
 from ._extract_json import extract_json
-from ._fuzzy_json import fuzzy_json
+from ._fuzzy_json import MAX_JSON_INPUT_SIZE, fuzzy_json
 from ._fuzzy_match import FuzzyMatchKeysParams, fuzzy_match_keys
 from ._fuzzy_validate import fuzzy_validate_mapping, fuzzy_validate_pydantic
 from ._string_similarity import SIMILARITY_TYPE, string_similarity
 from ._to_dict import to_dict
 
 __all__ = (
+    "MAX_JSON_INPUT_SIZE",
     "to_dict",
     "fuzzy_json",
     "fuzzy_match_keys",

--- a/lionagi/ln/fuzzy/_fuzzy_json.py
+++ b/lionagi/ln/fuzzy/_fuzzy_json.py
@@ -2,58 +2,229 @@ import contextlib
 import re
 from typing import Any
 
-import msgspec
+import orjson
 
-_decoder = msgspec.json.Decoder(type=Any)
+# Security limit: Maximum input string size for JSON parsing.
+# Large inputs can cause memory exhaustion during parsing and regex operations.
+# Default: 10MB - generous for most use cases while preventing DoS.
+MAX_JSON_INPUT_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
-def fuzzy_json(str_to_parse: str, /) -> dict[str, Any] | list[dict[str, Any]]:
-    """
-    Attempt to parse a JSON string, trying a few minimal "fuzzy" fixes if needed.
+def fuzzy_json(
+    str_to_parse: str,
+    /,
+    *,
+    max_size: int = MAX_JSON_INPUT_SIZE,
+) -> dict[str, Any] | list:
+    """Parse JSON string with fuzzy error correction (quotes, spacing, brackets).
+
+    Security Note:
+        Input size is limited to prevent memory exhaustion attacks.
+
+    Limitation:
+        This is designed for "nearly-valid" JSON from LLMs (single quotes, trailing
+        commas, unquoted keys). It is NOT a security boundary for adversarial input.
 
     Steps:
-    1. Parse directly with msgspec.
-    2. Replace single quotes with double quotes, normalize spacing, and try again.
-    3. Attempt to fix unmatched brackets using fix_json_string.
-    4. If all fail, raise ValueError.
+    1. Parse directly with orjson.
+    2. State-machine cleaning (safe quote/key/comma fixing).
+    3. Regex-based cleaning fallback.
+    4. Attempt to fix unmatched brackets using fix_json_string.
+    5. If all fail, raise ValueError.
 
     Args:
-        str_to_parse: The JSON string to parse
+        str_to_parse: The JSON string to parse.
+        max_size: Maximum allowed input size in bytes (default: 10MB).
 
     Returns:
-        Parsed JSON (dict or list of dicts)
+        A dict or list. Will NOT return bare primitive types
+        (int, float, str, bool, None).
 
     Raises:
-        ValueError: If the string cannot be parsed as valid JSON
-        TypeError: If the input is not a string
+        TypeError: If input is not a string or parsed JSON is a primitive type.
+        ValueError: If input is empty, exceeds size limit, or parsing fails.
     """
-    _check_valid_str(str_to_parse)
-
-    # Use .encode("utf-8") as msgspec typically works with bytes for optimal performance
+    _check_valid_str(str_to_parse, max_size=max_size)
 
     # 1. Direct attempt
-    with contextlib.suppress(msgspec.DecodeError):
-        return _decoder.decode(str_to_parse.encode("utf-8"))
+    with contextlib.suppress(orjson.JSONDecodeError):
+        return _validate_return_type(orjson.loads(str_to_parse))
 
-    # 2. Try cleaning: replace single quotes with double and normalize
-    cleaned = _clean_json_string(str_to_parse.replace("'", '"'))
-    with contextlib.suppress(msgspec.DecodeError):
-        return _decoder.decode(cleaned.encode("utf-8"))
+    # 2. State-machine cleaning (preserves string content)
+    cleaned = _clean_json_string_safe(str_to_parse)
+    with contextlib.suppress(orjson.JSONDecodeError):
+        return _validate_return_type(orjson.loads(cleaned))
 
-    # 3. Try fixing brackets
-    fixed = fix_json_string(cleaned)
-    with contextlib.suppress(msgspec.DecodeError):
-        return _decoder.decode(fixed.encode("utf-8"))
+    # 3. Regex-based cleaning fallback
+    cleaned_regex = _clean_json_string(str_to_parse.replace("'", '"'))
+    with contextlib.suppress(orjson.JSONDecodeError):
+        return _validate_return_type(orjson.loads(cleaned_regex))
+
+    # 4. Try fixing brackets (on best cleaned result)
+    for candidate in (cleaned, cleaned_regex):
+        fixed = fix_json_string(candidate)
+        with contextlib.suppress(orjson.JSONDecodeError):
+            return _validate_return_type(orjson.loads(fixed))
 
     # If all attempts fail
     raise ValueError("Invalid JSON string")
 
 
-def _check_valid_str(str_to_parse: str, /):
+def _check_valid_str(
+    str_to_parse: str,
+    /,
+    *,
+    max_size: int = MAX_JSON_INPUT_SIZE,
+) -> None:
+    """Validate input string for JSON parsing.
+
+    Args:
+        str_to_parse: Input string to validate
+        max_size: Maximum allowed size in bytes
+
+    Raises:
+        TypeError: If input is not a string
+        ValueError: If input is empty or exceeds size limit
+    """
     if not isinstance(str_to_parse, str):
         raise TypeError("Input must be a string")
     if not str_to_parse.strip():
         raise ValueError("Input string is empty")
+    if len(str_to_parse) > max_size:
+        msg = (
+            f"Input size ({len(str_to_parse)} bytes) exceeds maximum "
+            f"({max_size} bytes). This limit prevents memory exhaustion."
+        )
+        raise ValueError(msg)
+
+
+def _validate_return_type(
+    result: Any,
+) -> dict[str, Any] | list:
+    """Validate that parsed JSON is a structured type (dict or list).
+
+    Rejects bare primitives (int, float, str, bool, None) since fuzzy_json
+    is intended for structured data parsing.
+
+    Args:
+        result: The result from JSON decoding.
+
+    Returns:
+        The validated result (dict or list).
+
+    Raises:
+        TypeError: If result is a bare primitive type.
+    """
+    if isinstance(result, (dict, list)):
+        return result
+
+    raise TypeError(
+        f"fuzzy_json returns dict or list, got primitive type: {type(result).__name__}"
+    )
+
+
+def _clean_json_string_safe(s: str) -> str:
+    """State-machine JSON cleaner that preserves string content.
+
+    Fixes common LLM output issues without corrupting quoted content:
+    - Single quotes -> double quotes (with escaping)
+    - Trailing commas before ] or }
+    - Unquoted object keys
+    """
+    result: list[str] = []
+    pos = 0
+    length = len(s)
+
+    while pos < length:
+        char = s[pos]
+
+        if char == "'":  # Convert single-quoted string to double-quoted
+            result.append('"')
+            pos += 1
+            while pos < length:
+                inner_char = s[pos]
+                if inner_char == "\\":  # Escape sequence
+                    if pos + 1 < length:
+                        next_char = s[pos + 1]
+                        if next_char == "'":  # \' -> apostrophe
+                            result.append("'")
+                            pos += 2
+                            continue
+                        result.append(inner_char)
+                        result.append(next_char)
+                        pos += 2
+                        continue
+                    result.append(inner_char)
+                    pos += 1
+                    continue
+                if inner_char == "'":  # End single-quoted string
+                    result.append('"')
+                    pos += 1
+                    break
+                if inner_char == '"':  # Escape inner double quotes
+                    result.append('\\"')
+                    pos += 1
+                    continue
+                result.append(inner_char)
+                pos += 1
+            continue
+
+        if char == '"':  # Pass through double-quoted strings
+            result.append(char)
+            pos += 1
+            while pos < length:
+                inner_char = s[pos]
+                if inner_char == "\\":  # Copy escape sequences
+                    result.append(inner_char)
+                    if pos + 1 < length:
+                        pos += 1
+                        result.append(s[pos])
+                    pos += 1
+                    continue
+                result.append(inner_char)
+                if inner_char == '"':
+                    pos += 1
+                    break
+                pos += 1
+            continue
+
+        if char in "{,":  # Handle unquoted keys and trailing commas
+            if char == ",":  # Check for trailing comma
+                lookahead = pos + 1
+                while lookahead < length and s[lookahead] in " \t\n\r":
+                    lookahead += 1
+                if lookahead < length and s[lookahead] in "]}":
+                    pos += 1  # Skip trailing comma
+                    continue
+
+            result.append(char)
+            pos += 1
+
+            # Skip whitespace
+            while pos < length and s[pos] in " \t\n\r":
+                result.append(s[pos])
+                pos += 1
+
+            if pos < length and s[pos] not in "\"'{[":  # Unquoted key
+                key_start = pos
+                while pos < length and (s[pos].isalnum() or s[pos] == "_"):
+                    pos += 1
+                if pos < length and key_start < pos:
+                    key_end = pos
+                    while pos < length and s[pos] in " \t\n\r":
+                        pos += 1
+                    if pos < length and s[pos] == ":":
+                        key = s[key_start:key_end]
+                        result.append(f'"{key}"')
+                        continue
+                    else:
+                        pos = key_start  # Not a key, restore
+            continue
+
+        result.append(char)
+        pos += 1
+
+    return "".join(result).strip()
 
 
 def _clean_json_string(s: str) -> str:

--- a/lionagi/ln/fuzzy/_string_similarity.py
+++ b/lionagi/ln/fuzzy/_string_similarity.py
@@ -8,6 +8,14 @@ from typing import TYPE_CHECKING, Literal
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+try:
+    from rapidfuzz import distance as _rf_distance
+
+    _HAS_RAPIDFUZZ = True
+except ImportError:
+    _rf_distance = None  # type: ignore[assignment]
+    _HAS_RAPIDFUZZ = False
+
 
 __all__ = ("string_similarity",)
 
@@ -133,6 +141,9 @@ def jaro_winkler_similarity(s: str, t: str, scaling: float = 0.1) -> float:
     if not 0 <= scaling <= 0.25:
         raise ValueError("Scaling factor must be between 0 and 0.25")
 
+    if _HAS_RAPIDFUZZ:
+        return _rf_distance.JaroWinkler.similarity(s, t, prefix_weight=scaling)
+
     jaro_sim = jaro_distance(s, t)
 
     # Find length of common prefix (up to 4 chars)
@@ -196,6 +207,9 @@ def levenshtein_similarity(s1: str, s2: str) -> float:
     Returns:
         float: Levenshtein similarity score between 0 and 1
     """
+    if _HAS_RAPIDFUZZ:
+        return _rf_distance.Levenshtein.normalized_similarity(s1, s2)
+
     if not s1 and not s2:
         return 1.0
     if not s1 or not s2:

--- a/tests/libs/utils/test_fuzzy_parse_json.py
+++ b/tests/libs/utils/test_fuzzy_parse_json.py
@@ -1,6 +1,5 @@
 """Test suite for JSON utilities (fuzzy_json, extract_json) - TDD Specification Implementation."""
 
-import msgspec
 import pytest
 
 from lionagi.ln.fuzzy._extract_json import extract_json


### PR DESCRIPTION
## Summary
- Add cryptographic hashing (HashAlgorithm, compute_hash, compute_chain_hash) with DoS protection
- Add security hardening: MAX_JSON_INPUT_SIZE/MAX_HASH_INPUT_BYTES limits, type-loading allowlist
- Replace msgspec with orjson for JSON parsing; make msgspec Struct optional
- Add optional rapidfuzz acceleration for string similarity hot paths
- Add LazyInit, load_type_from_string, to_uuid, coerce_created_at, synchronized decorators

## Changes
- `lionagi/ln/_lazy_init.py` - New: thread-safe deferred initialization
- `lionagi/ln/_hash.py` - HashAlgorithm enum, compute_hash/compute_chain_hash, LazyInit
- `lionagi/ln/_json_dump.py` - DRY serialization loop, as_loaded param
- `lionagi/ln/_utils.py` - 6 new utility functions + timeout support
- `lionagi/ln/_to_list.py` - LazyInit pattern, skip_types as parameter
- `lionagi/ln/fuzzy/_fuzzy_json.py` - orjson, state-machine cleaner, size limits
- `lionagi/ln/fuzzy/_extract_json.py` - orjson, max_size DoS protection
- `lionagi/ln/fuzzy/_string_similarity.py` - Optional rapidfuzz for 10-100x faster similarity
- `lionagi/ln/__init__.py` + `fuzzy/__init__.py` - Updated exports
- `.pre-commit-config.yaml` - Fix check-yaml for mkdocs !ENV tag
- Tests updated for new validation behavior

## Test plan
- [ ] All existing tests pass (3196+ tests, 55 fuzzy_json tests)
- [ ] `from lionagi.ln import HashAlgorithm, compute_hash, load_type_from_string` works
- [ ] fuzzy_json rejects inputs > 10MB
- [ ] String similarity uses rapidfuzz when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)