### PR TITLE
fix(session): Branch.from_dict round-trip serialization

### DIFF
--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -471,7 +471,12 @@ class iModel:
             provider=endpoint.config.provider,
             endpoint=endpoint.config.endpoint,
         ):
+            # Preserve the API key from the freshly matched endpoint
+            # (reads from env), then apply the serialized config on top
+            fresh_api_key = e1.config._api_key
             e1.config = endpoint.config
+            if e1.config._api_key is None and fresh_api_key:
+                e1.config._api_key = fresh_api_key
         else:
             e1 = endpoint
 

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -539,6 +539,14 @@ class Branch(Element, Relational):
             "system": data.pop("system", Unset),
             "log_config": data.pop("log_config", Unset),
         }
+
+        # When restoring from serialized state, the system message is already
+        # in the messages pile. Don't pass it again to __init__ or it'll duplicate.
+        messages_val = dict_.get("messages", Unset)
+        system_val = dict_.get("system", Unset)
+        if messages_val is not Unset and system_val is not Unset:
+            dict_["system"] = Unset  # already in messages, skip re-adding
+
         params = {}
 
         # Merge in the rest of the data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lionagi"
-version = "0.20.2"
+version = "0.20.3"
 description = "An Intelligence Operating System."
 authors = [
     { name = "HaiyangLi", email = "quantocean.li@gmail.com" },


### PR DESCRIPTION
## Summary

- Fix `Branch.from_dict()` duplicate system message error (ItemExistsError) by skipping re-add when messages pile already contains it
- Fix `iModel.from_dict()` API key loss by preserving key from fresh `match_endpoint` after config overlay
- Bump version to 0.20.3

Enables: `Branch.to_dict()` -> store -> `Branch.from_dict()` -> continue conversation with full context preservation.

## Test plan

- [x] `Branch.from_dict()` round-trip: chat -> serialize -> deserialize -> chat again (same context)
- [x] API key restored from environment after deserialization
- [x] Messages count preserved across round-trip

Generated with [Claude Code](https://claude.com/claude-code)