### PR TITLE
feat: branch.run() — streaming CLI operation with StreamChunk

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -12,6 +12,7 @@ from lionagi import Branch, iModel, json_dumps
 from lionagi.ln import acreate_path
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
+from lionagi.protocols.messages import AssistantResponse
 
 from ._persistence import (
     LIONAGI_HOME,
@@ -99,7 +100,10 @@ async def _run_agent(
         # so persisted verbose/yolo don't leak into new invocations
         branch.chat_model.endpoint.config.kwargs["verbose_output"] = verbose
 
-    res = await branch.communicate(prompt)
+    res = ""
+    async for msg in branch.run(prompt):
+        if isinstance(msg, AssistantResponse):
+            res = msg.response
 
     path = await acreate_path(
         directory=LIONAGI_HOME / "logs" / "agents" / provider,

--- a/lionagi/operations/run/__init__.py
+++ b/lionagi/operations/run/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -20,33 +20,40 @@ if TYPE_CHECKING:
 
 async def run(
     branch: Branch,
-    instruction: str = "",
+    instruction=None,
+    chat_model=None,
+    sender=None,
+    recipient=None,
+    guidance=None,
+    context=None,
+    images=None,
+    image_detail=None,
     **kwargs,
 ) -> AsyncGenerator[RoledMessage, None]:
     """Stream Messages from a CLI endpoint.
 
     Yields Instruction, AssistantResponse, ActionRequest, and ActionResponse
-    messages as they arrive from the endpoint's stream_chunks().
+    messages as they arrive from the endpoint stream.
 
-    Args:
-        branch: The Branch to operate on.
-        instruction: The user instruction string.
-        **kwargs: Forwarded to stream_chunks(). Special keys consumed here:
-            sender, recipient, guidance, context, images, image_detail.
+    Accepts chat_model to override the branch default, enabling
+    multi-model conversations on a single branch:
+
+        sonnet = iModel(model="claude_code/sonnet")
+        codex  = iModel(model="codex/gpt-5.3-codex-spark")
+        async for msg in branch.run("step 1", chat_model=sonnet): ...
+        async for msg in branch.run("step 2", chat_model=codex): ...
     """
-    endpoint = branch.chat_model.endpoint
-
-    # Build and add the Instruction message
-    ins = branch.msgs.create_instruction(
+    model = chat_model or branch.chat_model
+    endpoint = model.endpoint
+    ins = branch.msgs.add_message(
         instruction=instruction,
-        sender=kwargs.get("sender") or branch.user or "user",
-        recipient=kwargs.get("recipient") or branch.id,
-        guidance=kwargs.get("guidance"),
-        context=kwargs.get("context"),
-        images=kwargs.get("images"),
-        image_detail=kwargs.get("image_detail", "auto"),
+        sender=sender,
+        recipient=recipient,
+        guidance=guidance,
+        context=context,
+        images=images,
+        image_detail=image_detail,
     )
-    branch.msgs.add_message(instruction=ins)
     yield ins
 
     # Build the request dict for the endpoint
@@ -57,14 +64,10 @@ async def run(
         if hasattr(msg, "chat_msg") and msg.chat_msg is not None:
             chat_msgs.append(msg.chat_msg)
 
-    # Keys consumed above — don't forward them to the endpoint
-    _consumed = {"sender", "recipient", "guidance", "context", "images", "image_detail"}
-    stream_kw = {k: v for k, v in kwargs.items() if k not in _consumed}
-
     request_dict: dict = {
         "messages": chat_msgs,
         **({"resume": session_id} if session_id else {}),
-        **stream_kw,
+        **kwargs,
     }
 
     # Accumulation buffers

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+from lionagi.protocols.messages.action_request import ActionRequest
+from lionagi.protocols.messages.action_response import ActionResponse
+from lionagi.protocols.messages.assistant_response import (
+    AssistantResponse,
+    AssistantResponseContent,
+)
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.message import RoledMessage
+    from lionagi.session.branch import Branch
+
+
+async def run(
+    branch: Branch,
+    instruction: str = "",
+    **kwargs,
+) -> AsyncGenerator[RoledMessage, None]:
+    """Stream Messages from a CLI endpoint.
+
+    Yields Instruction, AssistantResponse, ActionRequest, and ActionResponse
+    messages as they arrive from the endpoint's stream_chunks().
+
+    Args:
+        branch: The Branch to operate on.
+        instruction: The user instruction string.
+        **kwargs: Forwarded to stream_chunks(). Special keys consumed here:
+            sender, recipient, guidance, context, images, image_detail.
+    """
+    endpoint = branch.chat_model.endpoint
+
+    # Build and add the Instruction message
+    ins = branch.msgs.create_instruction(
+        instruction=instruction,
+        sender=kwargs.get("sender") or branch.user or "user",
+        recipient=kwargs.get("recipient") or branch.id,
+        guidance=kwargs.get("guidance"),
+        context=kwargs.get("context"),
+        images=kwargs.get("images"),
+        image_detail=kwargs.get("image_detail", "auto"),
+    )
+    branch.msgs.add_message(instruction=ins)
+    yield ins
+
+    # Build the request dict for the endpoint
+    session_id = getattr(endpoint, "session_id", None)
+    chat_msgs = []
+    for msg_id in branch.msgs.progression:
+        msg = branch.msgs.messages[msg_id]
+        if hasattr(msg, "chat_msg") and msg.chat_msg is not None:
+            chat_msgs.append(msg.chat_msg)
+
+    # Keys consumed above — don't forward them to the endpoint
+    _consumed = {"sender", "recipient", "guidance", "context", "images", "image_detail"}
+    stream_kw = {k: v for k, v in kwargs.items() if k not in _consumed}
+
+    request_dict: dict = {
+        "messages": chat_msgs,
+        **({"resume": session_id} if session_id else {}),
+        **stream_kw,
+    }
+
+    # Accumulation buffers
+    thinking_parts: list[str] = []
+    text_parts: list[str] = []
+
+    def _flush_response() -> AssistantResponse | None:
+        """Build an AssistantResponse from accumulated text/thinking chunks."""
+        if not text_parts:
+            return None
+        text = "".join(text_parts)
+        metadata: dict = {}
+        if thinking_parts:
+            metadata["thinking"] = "\n".join(thinking_parts)
+
+        res = AssistantResponse(
+            content=AssistantResponseContent(assistant_response=text),
+            sender=branch.id,
+            recipient=branch.user or "user",
+        )
+        if metadata:
+            res.metadata.update(metadata)
+        branch.msgs.add_message(assistant_response=res)
+        text_parts.clear()
+        thinking_parts.clear()
+        return res
+
+    # tool_id → ActionRequest, for linking tool_result chunks
+    pending_requests: dict[str, ActionRequest] = {}
+
+    async for chunk in endpoint.stream(request_dict):
+        match chunk.type:
+            case "system":
+                # Store session_id on the endpoint for future resume
+                if sid := chunk.metadata.get("session_id"):
+                    endpoint.session_id = sid
+
+            case "thinking":
+                if chunk.content:
+                    thinking_parts.append(chunk.content)
+
+            case "text":
+                if chunk.content:
+                    text_parts.append(chunk.content)
+
+            case "tool_use":
+                # Flush any accumulated text before the tool call
+                if res := _flush_response():
+                    yield res
+
+                act_req = branch.msgs.create_action_request(
+                    function=chunk.tool_name or "",
+                    arguments=chunk.tool_input or {},
+                    sender=branch.id,
+                    recipient=branch.user or "user",
+                )
+                if chunk.tool_id:
+                    pending_requests[chunk.tool_id] = act_req
+                branch.msgs.add_message(action_request=act_req)
+                yield act_req
+
+            case "tool_result":
+                # Link to the originating ActionRequest when we have the id
+                orig_req = (
+                    pending_requests.pop(chunk.tool_id, None)
+                    if chunk.tool_id
+                    else None
+                )
+                if orig_req is not None:
+                    act_res = branch.msgs.create_action_response(
+                        action_request=orig_req,
+                        action_output=chunk.tool_output,
+                        sender=branch.user or "user",
+                        recipient=branch.id,
+                    )
+                else:
+                    # No matching request (e.g. resumed session mid-stream)
+                    act_res = ActionResponse(
+                        content={
+                            "function": chunk.tool_name or "",
+                            "arguments": {},
+                            "output": chunk.tool_output,
+                        },
+                        sender=branch.user or "user",
+                        recipient=branch.id,
+                    )
+                    if chunk.is_error:
+                        act_res.metadata["is_error"] = True
+                    if chunk.tool_id:
+                        act_res.metadata["tool_id"] = chunk.tool_id
+                    branch.msgs.messages.include(act_res)
+                yield act_res
+
+            case "result":
+                pass  # Stats/timing — no message needed
+
+            case "error":
+                raise RuntimeError(chunk.content or "Stream error from CLI endpoint")
+
+    # Flush any remaining accumulated text
+    if res := _flush_response():
+        yield res

--- a/lionagi/service/connections/cli_endpoint.py
+++ b/lionagi/service/connections/cli_endpoint.py
@@ -16,6 +16,8 @@ class CLIEndpoint(Endpoint):
     - They may maintain sessions with resumption.
     - They manage their own context and actions.
     - They use subprocess + NDJSON streaming, not aiohttp + JSON.
+
+    Subclasses must implement ``stream()`` yielding ``StreamChunk`` objects.
     """
 
     is_cli: ClassVar[bool] = True

--- a/lionagi/service/connections/providers/claude_code_cli.py
+++ b/lionagi/service/connections/providers/claude_code_cli.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from lionagi.service.connections.cli_endpoint import CLIEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
+from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
 
 from ...third_party.claude_code import ClaudeChunk, ClaudeCodeRequest, ClaudeSession
@@ -77,12 +78,72 @@ class ClaudeCodeCLIEndpoint(CLIEndpoint):
 
     async def stream(
         self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[ClaudeChunk | dict | ClaudeSession]:
+    ) -> AsyncIterator[StreamChunk]:
         payload, _ = self.create_payload(request, **kwargs)
         request_obj = payload["request"]
         async with contextlib.aclosing(stream_claude_code_cli(request_obj)) as gen:
-            async for chunk in gen:
-                yield chunk
+            async for item in gen:
+                if isinstance(item, ClaudeSession):
+                    continue
+                if isinstance(item, dict):
+                    typ = item.get("type", "")
+                    if typ == "system":
+                        yield StreamChunk(
+                            type="system",
+                            metadata={
+                                "session_id": item.get("session_id"),
+                                "model": item.get("model"),
+                                "tools": item.get("tools", []),
+                            },
+                        )
+                    elif typ == "result":
+                        yield StreamChunk(
+                            type="result",
+                            content=item.get("result", ""),
+                            metadata={
+                                k: item.get(k)
+                                for k in (
+                                    "usage",
+                                    "total_cost_usd",
+                                    "num_turns",
+                                    "duration_ms",
+                                    "duration_api_ms",
+                                )
+                                if item.get(k) is not None
+                            },
+                            is_error=item.get("is_error", False),
+                        )
+                    continue
+                if isinstance(item, ClaudeChunk):
+                    raw = item.raw
+                    if item.type in ("assistant", "user"):
+                        msg = raw.get("message", {})
+                        for blk in msg.get("content", []):
+                            btype = blk.get("type")
+                            if btype == "thinking":
+                                yield StreamChunk(
+                                    type="thinking",
+                                    content=blk.get("thinking", ""),
+                                )
+                            elif btype == "text":
+                                yield StreamChunk(
+                                    type="text",
+                                    content=blk.get("text", ""),
+                                )
+                            elif btype == "tool_use":
+                                yield StreamChunk(
+                                    type="tool_use",
+                                    tool_name=blk.get("name"),
+                                    tool_id=blk.get("id"),
+                                    tool_input=blk.get("input"),
+                                )
+                            elif btype == "tool_result":
+                                yield StreamChunk(
+                                    type="tool_result",
+                                    tool_id=blk.get("tool_use_id"),
+                                    tool_output=blk.get("content"),
+                                    is_error=blk.get("is_error", False),
+                                )
 
     async def _call(
         self,

--- a/lionagi/service/connections/providers/codex_cli.py
+++ b/lionagi/service/connections/providers/codex_cli.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from lionagi.service.connections.cli_endpoint import CLIEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
+from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
 
 from ...third_party.codex_models import CodexChunk, CodexCodeRequest, CodexSession
@@ -74,12 +75,52 @@ class CodexCLIEndpoint(CLIEndpoint):
 
     async def stream(
         self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[CodexChunk | dict | CodexSession]:
+    ) -> AsyncIterator[StreamChunk]:
         payload, _ = self.create_payload(request, **kwargs)
         request_obj = payload["request"]
         async with contextlib.aclosing(stream_codex_cli(request_obj)) as gen:
-            async for chunk in gen:
-                yield chunk
+            async for item in gen:
+                if isinstance(item, CodexSession):
+                    continue
+                if isinstance(item, dict):
+                    typ = item.get("type", "")
+                    if typ == "result":
+                        yield StreamChunk(
+                            type="result",
+                            content=item.get("result", ""),
+                            metadata=item,
+                        )
+                    continue
+                if isinstance(item, CodexChunk):
+                    if item.text is not None:
+                        yield StreamChunk(type="text", content=item.text)
+                    if item.tool_use is not None:
+                        tu = item.tool_use
+                        yield StreamChunk(
+                            type="tool_use",
+                            tool_name=tu.get("name"),
+                            tool_id=tu.get("id"),
+                            tool_input=tu.get("input"),
+                        )
+                    if item.tool_result is not None:
+                        tr = item.tool_result
+                        yield StreamChunk(
+                            type="tool_result",
+                            tool_id=tr.get("tool_use_id"),
+                            tool_output=tr.get("content"),
+                            is_error=tr.get("is_error", False),
+                        )
+                    if (
+                        item.text is None
+                        and item.tool_use is None
+                        and item.tool_result is None
+                        and item.type == "result"
+                    ):
+                        yield StreamChunk(
+                            type="result",
+                            content=item.raw.get("result", ""),
+                            metadata=item.raw,
+                        )
 
     async def _call(
         self,

--- a/lionagi/service/connections/providers/gemini_cli.py
+++ b/lionagi/service/connections/providers/gemini_cli.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from lionagi.service.connections.cli_endpoint import CLIEndpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
+from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.utils import to_dict
 
 from ...third_party.gemini_models import GeminiChunk, GeminiCodeRequest, GeminiSession
@@ -74,12 +75,56 @@ class GeminiCLIEndpoint(CLIEndpoint):
 
     async def stream(
         self, request: dict | BaseModel, **kwargs
-    ) -> AsyncIterator[GeminiChunk | dict | GeminiSession]:
+    ) -> AsyncIterator[StreamChunk]:
         payload, _ = self.create_payload(request, **kwargs)
         request_obj = payload["request"]
         async with contextlib.aclosing(stream_gemini_cli(request_obj)) as gen:
-            async for chunk in gen:
-                yield chunk
+            async for item in gen:
+                if isinstance(item, GeminiSession):
+                    continue
+                if isinstance(item, dict):
+                    typ = item.get("type", "")
+                    if typ == "result":
+                        yield StreamChunk(
+                            type="result",
+                            content=item.get("result", ""),
+                            metadata=item,
+                        )
+                    continue
+                if isinstance(item, GeminiChunk):
+                    if item.text is not None:
+                        yield StreamChunk(
+                            type="text",
+                            content=item.text,
+                            is_delta=item.is_delta,
+                        )
+                    if item.tool_use is not None:
+                        tu = item.tool_use
+                        yield StreamChunk(
+                            type="tool_use",
+                            tool_name=tu.get("name"),
+                            tool_id=tu.get("id"),
+                            tool_input=tu.get("input"),
+                        )
+                    if item.tool_result is not None:
+                        tr = item.tool_result
+                        yield StreamChunk(
+                            type="tool_result",
+                            tool_id=tr.get("tool_use_id"),
+                            tool_output=tr.get("content"),
+                            is_error=tr.get("is_error", False),
+                        )
+                    if (
+                        item.text is None
+                        and item.tool_use is None
+                        and item.tool_result is None
+                        and item.type == "result"
+                    ):
+                        yield StreamChunk(
+                            type="result",
+                            content=item.raw.get("result", ""),
+                            metadata=item.raw,
+                        )
 
     async def _call(
         self,

--- a/lionagi/service/types/__init__.py
+++ b/lionagi/service/types/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from .stream_chunk import StreamChunk
+
+__all__ = ("StreamChunk",)

--- a/lionagi/service/types/stream_chunk.py
+++ b/lionagi/service/types/stream_chunk.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+ChunkType = Literal[
+    "system",       # session init (model, session_id, tools)
+    "thinking",     # reasoning trace
+    "text",         # assistant text content
+    "tool_use",     # model requests a tool call
+    "tool_result",  # tool execution output
+    "result",       # final aggregated result
+    "error",        # error
+]
+
+
+@dataclass(slots=True)
+class StreamChunk:
+    """Provider-agnostic streaming chunk.
+
+    Endpoints convert provider-specific formats (ClaudeChunk, etc.)
+    into StreamChunk. Operations consume StreamChunk to build Messages.
+    """
+
+    type: ChunkType
+    content: str | None = None
+    tool_name: str | None = None
+    tool_id: str | None = None
+    tool_input: dict[str, Any] | None = None
+    tool_output: Any | None = None
+    is_error: bool = False
+    is_delta: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -1309,6 +1309,7 @@ class Branch(Element, Relational):
         self,
         instruction: str = "",
         *,
+        chat_model: "iModel | None" = None,
         guidance=None,
         context=None,
         sender=None,
@@ -1319,25 +1320,18 @@ class Branch(Element, Relational):
     ) -> "AsyncGenerator[RoledMessage, None]":
         """Stream Messages from a CLI endpoint.
 
-        Yields an Instruction message immediately, then yields
-        AssistantResponse, ActionRequest, and ActionResponse messages
-        as they arrive from the CLI endpoint's stream_chunks().
+        Yields Instruction, AssistantResponse, ActionRequest, and
+        ActionResponse messages as they arrive from the stream.
 
-        Args:
-            instruction: The user instruction string.
-            guidance: Optional guidance text for the instruction.
-            context: Optional context data for the instruction.
-            sender: Sender ID or role for the instruction.
-            recipient: Recipient ID or role for the instruction.
-            images: Optional images to include in the instruction.
-            image_detail: Image detail level ("low", "high", "auto").
-            **kwargs: Additional keyword arguments forwarded to stream_chunks().
+        Pass ``chat_model`` to override the branch default, enabling
+        multi-model conversations on a single branch.
         """
         from lionagi.operations.run.run import run as _run
 
         async for msg in _run(
             self,
             instruction=instruction,
+            chat_model=chat_model,
             guidance=guidance,
             context=context,
             sender=sender,

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -1305,5 +1305,48 @@ class Branch(Element, Relational):
             else:
                 yield result
 
+    async def run(
+        self,
+        instruction: str = "",
+        *,
+        guidance=None,
+        context=None,
+        sender=None,
+        recipient=None,
+        images=None,
+        image_detail="auto",
+        **kwargs,
+    ) -> "AsyncGenerator[RoledMessage, None]":
+        """Stream Messages from a CLI endpoint.
+
+        Yields an Instruction message immediately, then yields
+        AssistantResponse, ActionRequest, and ActionResponse messages
+        as they arrive from the CLI endpoint's stream_chunks().
+
+        Args:
+            instruction: The user instruction string.
+            guidance: Optional guidance text for the instruction.
+            context: Optional context data for the instruction.
+            sender: Sender ID or role for the instruction.
+            recipient: Recipient ID or role for the instruction.
+            images: Optional images to include in the instruction.
+            image_detail: Image detail level ("low", "high", "auto").
+            **kwargs: Additional keyword arguments forwarded to stream_chunks().
+        """
+        from lionagi.operations.run.run import run as _run
+
+        async for msg in _run(
+            self,
+            instruction=instruction,
+            guidance=guidance,
+            context=context,
+            sender=sender,
+            recipient=recipient,
+            images=images,
+            image_detail=image_detail,
+            **kwargs,
+        ):
+            yield msg
+
 
 # File: lionagi/session/branch.py

--- a/tests/service/connections/providers/test_claude_code_cli.py
+++ b/tests/service/connections/providers/test_claude_code_cli.py
@@ -260,23 +260,30 @@ class TestStreamMethod:
 
     @pytest.mark.asyncio
     async def test_stream_yields_chunks(self):
-        """Test stream method yields chunks from CLI."""
+        """Test stream method yields StreamChunk objects."""
         from lionagi.service.connections.providers.claude_code_cli import (
             ClaudeCodeCLIEndpoint,
         )
+        from lionagi.service.third_party.claude_code import ClaudeChunk
+        from lionagi.service.types.stream_chunk import StreamChunk
 
         with patch(
             "lionagi.service.connections.providers.claude_code_cli.stream_claude_code_cli"
         ) as mock_stream:
-            # Create mock chunks
-            mock_chunk1 = MagicMock()
-            mock_chunk1.text = "chunk1"
-            mock_chunk2 = MagicMock()
-            mock_chunk2.text = "chunk2"
+            chunk1 = ClaudeChunk(
+                raw={"type": "assistant", "message": {"content": [{"type": "text", "text": "hello"}]}},
+                type="assistant",
+                text="hello",
+            )
+            chunk2 = ClaudeChunk(
+                raw={"type": "assistant", "message": {"content": [{"type": "text", "text": "world"}]}},
+                type="assistant",
+                text="world",
+            )
 
             async def async_gen(*args, **kwargs):
-                yield mock_chunk1
-                yield mock_chunk2
+                yield chunk1
+                yield chunk2
 
             mock_stream.return_value = async_gen()
 
@@ -291,8 +298,10 @@ class TestStreamMethod:
                 chunks.append(chunk)
 
             assert len(chunks) == 2
-            assert chunks[0].text == "chunk1"
-            assert chunks[1].text == "chunk2"
+            assert all(isinstance(c, StreamChunk) for c in chunks)
+            assert chunks[0].type == "text"
+            assert chunks[0].content == "hello"
+            assert chunks[1].content == "world"
 
     @pytest.mark.asyncio
     async def test_stream_with_kwargs(self):


### PR DESCRIPTION
## Summary
- **`branch.run()`** — new async generator operation that yields `Message` objects from CLI endpoint streams
- **`StreamChunk`** — provider-agnostic streaming chunk type (`service/types/stream_chunk.py`)
- **CLI endpoints** (`claude_code`, `codex`, `gemini`) — `stream()` now yields `StreamChunk` instead of provider-specific types
- **Multi-model support** — `chat_model` param lets you switch providers mid-conversation on a single branch

### Architecture
```
third_party (raw NDJSON) → endpoint.stream() (StreamChunk) → run() (Message)
```

### Usage
```python
sonnet = iModel(model="claude_code/sonnet")
gpt    = iModel(model="openai/gpt-4.1-mini")
branch = Branch()

# CLI streaming — yields Message objects
async for msg in branch.run("analyze this code", chat_model=sonnet):
    print(msg)

# Then switch to API for structured extraction — same branch context
result = await branch.operate(
    "extract info", chat_model=gpt, response_format=MyModel
)
```

### Message yield behavior
- `thinking` chunks → folded into `AssistantResponse.metadata["thinking"]`
- `text` chunks → accumulated → single `AssistantResponse`
- `tool_use` → `ActionRequest` (flushes pending text first)
- `tool_result` → `ActionResponse` (linked to originating request by tool_id)

## Test plan
- [x] Single run(), simple Q&A (2 messages)
- [x] Multi-turn context carry (same branch, 4 messages)
- [x] Tool use — Read/Bash (ActionRequest/Response pairs)
- [x] Switch chat_model between runs (context preserved)
- [x] Mixed run() + operate() with structured output (CityInfo extraction)
- [x] Persist/deserialize with mixed message types

🤖 Generated with [Claude Code](https://claude.com/claude-code)