### PR TITLE
refactor(cli): li agent uses branch.run()

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -12,6 +12,7 @@ from lionagi import Branch, iModel, json_dumps
 from lionagi.ln import acreate_path
 from lionagi.ln.concurrency import run_async
 from lionagi.protocols.generic.log import DataLoggerConfig
+from lionagi.protocols.messages import AssistantResponse
 
 from ._persistence import (
     LIONAGI_HOME,
@@ -99,7 +100,10 @@ async def _run_agent(
         # so persisted verbose/yolo don't leak into new invocations
         branch.chat_model.endpoint.config.kwargs["verbose_output"] = verbose
 
-    res = await branch.communicate(prompt)
+    res = ""
+    async for msg in branch.run(prompt):
+        if isinstance(msg, AssistantResponse):
+            res = msg.response
 
     path = await acreate_path(
         directory=LIONAGI_HOME / "logs" / "agents" / provider,


### PR DESCRIPTION
## Summary
- `li agent` now uses `branch.run()` instead of `branch.communicate()`
- Streams through the new `StreamChunk` → `Message` pipeline from #898
- Final `AssistantResponse.response` is collected as the result string

## Changes
- `cli/agent.py`: 2-line core change — `communicate()` → `async for msg in branch.run()`

## What didn't change
- Persistence (save/load branch JSON) — unchanged
- Resume (`-r` / `-c`) — unchanged, tested
- Verbose mode — still handled by endpoint's internal pretty-print
- Subparser / CLI flags — unchanged

## Test plan
- [x] `li agent claude "3+3"` → 6
- [x] `li agent claude "capital of France" -v` → Paris + verbose output
- [x] `li agent -c "what country is that"` → France (resume context)

Depends on #898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)