### PR TITLE
fix: CLI orchestration bugs — guidance coercion, worker tool access, output dedup

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -227,7 +227,7 @@ def run_agent(args: argparse.Namespace) -> int:
         )
     )
     if not args.verbose:
-        print(f"\n{result}" if result is not None else "")
+        print(f"\n{result}" if result is not None else "", flush=True)
 
     print(f'\n[to resume] li agent -r {branch_id} "..."', file=sys.stderr)
     return 0

--- a/lionagi/cli/orchestrate.py
+++ b/lionagi/cli/orchestrate.py
@@ -254,9 +254,8 @@ async def _run_fanout(
                 f"task the worker will answer itself — not a meta-instruction "
                 f"to generate more agents or decompose further. Workers are "
                 f"leaf executors, not orchestrators. "
-                f"Set actions=false and reason=false in every instruct — "
-                f"workers must NOT use tools, spawn agents, or read files. "
-                f"They answer from their own knowledge only. "
+                f"Workers CAN read files, use tools, and run commands "
+                f"as needed to complete their assigned sub-task. "
                 f"If multiple models are provided, set the model field to "
                 f"the exact model string from the list above. "
                 f"If all workers use the same model, model can be null."
@@ -319,9 +318,9 @@ async def _run_fanout(
             )
         else:
             worker_system = (
-                "You are a leaf worker agent. Answer the instruction directly "
-                "from your own knowledge. Do NOT spawn sub-agents, use tools, "
-                "or read files. Just answer concisely."
+                "You are a leaf worker agent. Complete your assigned task "
+                "directly. You may read files, use tools, and run commands "
+                "as needed. Do NOT spawn sub-agents or delegate further."
             )
         worker_branch = Branch(
             chat_model=worker_imodel,

--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -123,7 +123,12 @@ async def chat(
     if branch.msgs.system:
         messages = [msg for msg in messages if msg.role != "system"]
         first_instruction = None
-        f = lambda x: branch.msgs.system.rendered + (x.content.guidance or "")
+        def f(x):
+            g = x.content.guidance or ""
+            if not isinstance(g, str):
+                from lionagi.libs.schema.minimal_yaml import minimal_yaml
+                g = minimal_yaml(g).strip()
+            return branch.msgs.system.rendered + g
         if len(messages) == 0:
             first_instruction = ins.model_copy(
                 update={"content": ins.content.with_updates(guidance=f(ins))}

--- a/lionagi/service/connections/providers/codex_cli.py
+++ b/lionagi/service/connections/providers/codex_cli.py
@@ -144,19 +144,9 @@ class CodexCLIEndpoint(CLIEndpoint):
         codex_log.info(
             f"Session {session.session_id} finished with {len(responses)} chunks"
         )
-        texts = []
-        for i in session.chunks:
-            if i.text is not None:
-                texts.append(i.text)
-
-        # Guard against double-append: stream_codex_cli already populates
-        # session.result from chunks when the CLI doesn't emit a dedicated
-        # "response" event. Only append if it is genuinely new content.
-        if session.result and (
-            not texts or session.result.strip() != texts[-1].strip()
-        ):
-            texts.append(session.result)
-        session.result = "\n".join(texts)
+        if not session.result:
+            texts = [c.text for c in session.chunks if c.text is not None]
+            session.result = "\n".join(texts)
         if request.cli_include_summary:
             session.populate_summary()
 


### PR DESCRIPTION
## Summary
- **chat.py**: coerce non-string `guidance` (dict/list from `JsonValue`) to YAML before concatenating with system prompt — fixes `str + dict` TypeError crash in fanout workers
- **orchestrate.py**: allow fanout workers to read files and use tools instead of knowledge-only restriction — CLI agents need filesystem access for real tasks
- **codex_cli.py**: fix output duplication where `session.result` (already set by `stream_codex_cli`) was re-joined from chunks and appended again
- **agent.py**: add `flush=True` for proper stdout flushing when redirected to files in background execution

## Test plan
- [x] `li o fanout codex/gpt-5.4 "..." --yolo` — workers no longer crash with `str + dict`
- [x] Workers can read files and produce real results (tested with 274 session summary corpus)
- [x] Codex output no longer duplicated in fanout results
- [ ] `li agent codex "..." --yolo > output.md 2>&1 &` — output appears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)